### PR TITLE
Vesivaraaja scripts to not change relay status if the status in new hour is the same as previous hour

### DIFF
--- a/Scripts/Shelly-Minimal-Heating.js
+++ b/Scripts/Shelly-Minimal-Heating.js
@@ -1,5 +1,5 @@
 // Thank you for your support: https://www.buymeacoffee.com/spothintafi
-// Supported Shelly firmwares: 1.0.3 - 1.4.2. Script version: 2024-09-09
+// Supported Shelly firmwares: 1.0.3 - 1.4.2. Script version: 2024-10-09
 
 // Change these settings as you like
 let Region = "FI"; // Supported regions: DK1, DK2, EE, FI, LT, LV, NO1, NO2, NO3, NO4, NO5, SE1, SE2, SE3, SE4

--- a/Scripts/Shelly-Pikakoodi.js
+++ b/Scripts/Shelly-Pikakoodi.js
@@ -1,5 +1,5 @@
 ﻿// Kiitos tuestasi: https://www.buymeacoffee.com/spothintafi
-// Tuetut Shelly ohjelmistot: 1.0.3 - 1.4.2. Skriptin versio: 2024-09-09
+// Tuetut Shelly ohjelmistot: 1.0.3 - 1.4.2. Skriptin versio: 2024-10-09
 
 // OHJE: Anna "pikakoodi" kullekin ohjattavalle releelle. Koodilla 999 voit ohittaa releen.
 // Esimerkki 1: Ohjaa releitä 2 ja 3. Aseta pikakoodit näin: [999, 103, 125]

--- a/Scripts/Shelly-Rank-and-Price.js
+++ b/Scripts/Shelly-Rank-and-Price.js
@@ -1,5 +1,5 @@
 // Thank you for your support: https://www.buymeacoffee.com/spothintafi
-// Supported Shelly firmwares: 1.0.3 - 1.4.2. Script version: 2024-09-09
+// Supported Shelly firmwares: 1.0.3 - 1.4.2. Script version: 2024-10-09
 
 // Region to use
 let Region = "FI"; // Supported regions: DK1, DK2, EE, FI, LT, LV, NO1, NO2, NO3, NO4, NO5, SE1, SE2, SE3, SE4

--- a/Scripts/Shelly-SmartHeating.js
+++ b/Scripts/Shelly-SmartHeating.js
@@ -1,5 +1,5 @@
 // Thank you for your support: https://www.buymeacoffee.com/spothintafi
-// Supported Shelly firmwares: 1.0.3 - 1.4.2. Script version: 2024-09-09
+// Supported Shelly firmwares: 1.0.3 - 1.4.2. Script version: 2024-10-09
 
 // SmartHeating: outdoor temperature controlled heating with a possibility to control multiple relays with the same rules.
 // Note! At the worst case temperature is off by 10-15c degrees as the measuring station is not at your home, so make your own measurements if precision is required.     

--- a/Scripts/Shelly-SmartMonitoring.js
+++ b/Scripts/Shelly-SmartMonitoring.js
@@ -1,5 +1,5 @@
 // Thank you for your support: https://www.buymeacoffee.com/spothintafi
-// Supported Shelly firmwares: 1.0.3 - 1.4.2. Script version: 2024-09-09
+// Supported Shelly firmwares: 1.0.3 - 1.4.2. Script version: 2024-10-09
 
 // Common settings
 const Region = "FI"; // Supported regions: DK1, DK2, EE, FI, LT, LV, NO1, NO2, NO3, NO4, NO5, SE1, SE2, SE3, SE4

--- a/Scripts/Shelly-Vesivaraaja-yosiirto.js
+++ b/Scripts/Shelly-Vesivaraaja-yosiirto.js
@@ -1,22 +1,23 @@
 ﻿// Kiitos tuestasi: https://www.buymeacoffee.com/spothintafi
-// Tuetut Shelly ohjelmistot: 1.0.3 - 1.4.2. Skriptin versio: 2024-09-09
+// Tuetut Shelly ohjelmistot: 1.0.3 - 1.4.2. Skriptin versio: 2024-10-09
 
 // ASETUKSET
-let Rankit = [1, 2, 3];  // Listaa 'rankit' (eli tunnin järjestysnumero hinnan mukaan), jolloin rele kytketään
-let Rele = 0;  // Ohjattavan releen numero
+let Rankit = [1, 2, 3];      // Listaa 'rankit' (eli tunnin järjestysnumero hinnan mukaan), jolloin rele kytketään
+let Rele = 0;                // Ohjattavan releen numero
 let Yotunnit = [22, 23, 0, 1, 2, 3, 4, 5, 6]; // Yösiirron tunnit. Näihin ei tarvitse normaalisti koskea (edes kellonsiirron aikaan).
-let Hintaero = -1.43;  // Paljonko sähkön siirtohinta on halvempi yösiirron aikaan?
+let Hintaero = -1.43;        // Paljonko sähkön siirtohinta on halvempi yösiirron aikaan?
 let Varatunnit = [3, 4, 5];  // Tunnit jolloin rele kytketään, mikäli Internet yhteys ei toimi tai palvelu on alhaalla
 
 // KOODI
 let url = "https://api.spot-hinta.fi/JustNowRanksAndPrice?priorityHours=" + Yotunnit.join() + "&priceModifier=" + Hintaero + "&ranksAllowed=" + Rankit.join();
-let hour = -1; print("WaterBoiler: Ohjaus käynnistyy 30 sekunnissa.");
+let hour = -1; let previousAction = ""; print("WaterBoiler: Ohjaus käynnistyy 30 sekunnissa.");
 Timer.set(30000, true, function () {
     if (hour == new Date().getHours()) { print("WaterBoiler: Odotetaan tunnin vaihtumista."); return; }
     Shelly.call("HTTP.GET", { url: url, timeout: 15, ssl_ca: "*" }, function (res, err) {
         hour = (err != 0 || res == null || (res.code !== 200 && res.code !== 400)) ? -1 : new Date().getHours();
         let on = false;
         if (hour === -1) {
+            previousAction = "";
             if (Varatunnit.indexOf(new Date().getHours()) > -1) {
                 on = true; hour = new Date().getHours();
                 print("WaterBoiler: Virhetilanne. Kuluva tunti on varatunti: rele kytketään päälle tämän tunnin ajaksi.");
@@ -24,7 +25,13 @@ Timer.set(30000, true, function () {
                 print("WaterBoiler: Virhetilanne. Kuluva tunti ei ole varatunti: relettä ei kytketä. Yhteyttä yritetään uudestaan.");
             }
         } else { if (res.code === 200) { on = true; } }
-        Shelly.call("Switch.Set", "{ id:" + Rele + ", on:" + on + "}", null, null);
-        print("WaterBoiler: Kytketty " + (on ? "päälle" : "pois päältä"));
+
+        if (previousAction !== on) {
+            Shelly.call("Switch.Set", "{ id:" + Rele + ", on:" + on + "}", null, null);
+            print("WaterBoiler: Kytketty " + (on ? "päälle" : "pois päältä"));
+            previousAction = on;
+        } else {
+            print("WaterBoiler: Releen tilaa ei muutettu, koska se olisi sama kuin edellisellä tunnilla.");
+        }
     });
 });


### PR DESCRIPTION
Updates to "Vesivaraaja" scripts.  Both scripts were missing the feature to not touch the relay if status is not changing frrom the previous hour. This allows user to manually change the relay status and script does not change the status in the start of next hour, if status according to script should not be changed.