### PR TITLE
Fix bugs with Pikakoodit

### DIFF
--- a/Scripts/Shelly-Pikakoodi.js
+++ b/Scripts/Shelly-Pikakoodi.js
@@ -13,12 +13,12 @@ let Pikakoodit = [103];
 let rr = 0; let tunti = -1; let vtila = false; let tilat = [null, null, null, null]; print("Pikakoodi: Skripti käynnistyy.");
 Timer.set(30000, true, function () {
     if (tunti == new Date().getHours()) { print("Pikakoodi: Odotetaan tunnin vaihtumista."); return; }
-    if (rr < Pikakoodit.length) { ExecuteRelay(); rr++; return; }
-    if (vtila == false) { rr == 0; tunti = new Date().getHours(); return; } else { rr = 0; vtila = false; tunti = -1; return; }
+    if (rr < Pikakoodit.length) { ExecuteRelay(); return; }
+    if (vtila == false) { rr = 0; tunti = new Date().getHours(); return; } else { rr = 0; vtila = false; tunti = -1; return; }
 });
 
 function ExecuteRelay() {
-    if (Pikakoodit[rr] === 999 || Pikakoodit[rr] === undefined) { return; }
+    if (Pikakoodit[rr] === 999 || Pikakoodit[rr] === undefined) { rr++; return; }
     Shelly.call("HTTP.GET", { url: "https://api.spot-hinta.fi/QuickCode/" + Pikakoodit[rr], timeout: 10, ssl_ca: "*" }, RunResponse);
 }
 
@@ -31,4 +31,5 @@ function RunResponse(res, err) {
         print("Pikakoodi: Rele " + rr + " on kytketty " + (tila ? "päälle" : "pois päältä") + (!virhe ? "." : " (virhetilanne)."));
         if (virhe) { tilat[rr] = null; } else { tilat[rr] = tila; } // Aseta releen tila muistiin
     } else { print("Pikakoodi: Rele " + rr + " tilaa ei muutettu, koska tila on sama kuin edellisellä ohjauksella."); }
+    rr++;
 }


### PR DESCRIPTION
Fix bogus way of reseting relay ID (`rr == 0`), caused by [this refactoring](https://github.com/Spot-hinta-fi/Shelly/pull/80/files#diff-6344c0d62a48dde659b7446820a59371f12bda4f830123f20cccb9c113702ae2R17).

Also fix incrementing `rr`. As `Shelly.call` is asyncronous call, and the promise is not waited, the `rr` got increased immediately after the `ExecuteRelay` was called (before it completed). This caused `rr` to be off-by-one when turning relay on/off. 

I installed my first Shelly two days ago, and yesterday installed this script, and then been debugging why it behaves strangely. With these changes it seems to work now (still waiting for one more cycle of triggers to happen to be 100% sure). 