### PR TITLE
Changed default value for PriceAlwaysAllowed to -99, i.e. make it disabled by default

### DIFF
--- a/Scripts/Shelly-Minimal-Heating.js
+++ b/Scripts/Shelly-Minimal-Heating.js
@@ -10,7 +10,7 @@ let Relays = [0]; // Relays to control. For example: [0, 1, 2] to control three 
 let NightHours = [22, 23, 0, 1, 2, 3, 4, 5, 6]; // Night transfer hours. These usually don’t need to be changed (not even during daylight saving time changes).
 let PriceDifference = -1.43; // Difference between night and day prices. A negative value means the night transfer is cheaper by this amount. Information available from the electricity distribution company.
 let OnlyNightHours = false; // If true, cheapest hours are only searched from the night hours. Default is false == all hours.
-let PriceAlwaysAllowed = -1.43; // Daytime price that is always allowed. During night hours, prices higher by the amount of the PriceDifference are also allowed.
+let PriceAlwaysAllowed = -99; // Daytime price that is always allowed. During night hours PriceDifference is reduced from price before comparison. Disable with -99.
 let MaximumPrice = 99.9; // Maximum allowed price in euro cents.
 let BackupHours = [3, 4, 5, 6]; // If Internet connection is down, turn relay ON during these hours (0...23). Use [99], if you don't want any backup hours.
 let Inverted = false; // If "true", relay logic is inverted (= relay is turned ON when price is too exepensive and OFF when cheap)

--- a/Scripts/Shelly-Vesivaraaja-yosiirto.js
+++ b/Scripts/Shelly-Vesivaraaja-yosiirto.js
@@ -8,7 +8,7 @@ let HintajaksonPituus = 60; // Yhden hintajakson ("rank") kesto minuutteina (15,
 let Releet = [0]; // Ohjattavien releiden numerot. Esimerkiksi [0,1,2] ohjaa kolmea relettä.
 let Yotunnit = [22, 23, 0, 1, 2, 3, 4, 5, 6]; // Yösiirron tunnit. Näitä ei yleensä tarvitse muuttaa (myöskään kellonsiirron aikaan).
 let Hintaero = -1.43; // Yö- ja päivähinnan ero. Negatiivinen arvo = yösiirto on näin paljon halvempi. Siirtoyhtiöstä saatava tieto.
-let SallittuHinta = 0; // Päivähinta joka aina sallitaan. Yötunneilta sallitaan Hintaeron verran kalliimmatkin hinnat.
+let SallittuHinta = -99; // Päivähinta, joka aina sallitaan. Huom! Yöhinnoista vähennetään "Hintaero" ja sitä verrataan sallittuun hintaan. Pois käytöstä: -99
 let Varatunnit = [3, 4, 5]; // Tunnit, jolloin rele kytketään, jos ohjaustietoja ei saada haettua.
 
 // KOODI


### PR DESCRIPTION
Changed default value for PriceAlwaysAllowed to -99, i.e. make it disabled by default. Change was done to minimum-heating and vesivaraaja-yösiirto scripts.